### PR TITLE
Refactor iOS haptics around target refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 npm
 __pycache__/
 *.pyc
+
+.agents/memory

--- a/README.md
+++ b/README.md
@@ -31,11 +31,18 @@
 
 This package utilizes the `input[switch]` element introduced in
 [Safari 18.0](https://webkit.org/blog/15865/webkit-features-in-safari-18-0/) to
-trigger haptic feedback anytime, anywhere in your React application.
+trigger haptic feedback in React applications.
+
+On current iOS / WebKit, arbitrary programmatic haptic triggering is no longer
+reliable. The supported path is to let the user directly interact with a native
+`input[switch]`. `useHaptic()` now reflects that:
+
+- On iOS Safari, attach `ref` to the pressed element
+- On Android and other browsers, keep using `triggerHaptic()`
 
 ## 🚀 Features
 
-- ✅ Trigger haptic feedback at any time in your React application
+- ✅ Attach haptic behavior to any single React DOM target with `ref`
 - ✅ Support iOS, Android
 - ✅ Simple, intuitive API
 - ✅ Native TypeScript support by 🦕
@@ -70,10 +77,46 @@ deno add jsr:@posaune0423/use-haptic
 import { useHaptic } from "use-haptic";
 
 function HapticButton() {
-  const { triggerHaptic } = useHaptic();
-  return <button onClick={triggerHaptic}>Feel Haptic</button>;
+  const { ref } = useHaptic();
+
+  return (
+    <button onClick={() => console.log("pressed")} ref={ref} type="button">
+      Feel Haptic
+    </button>
+  );
 }
 ```
+
+The hook places a transparent native `input[switch]` on top of the referenced
+element so Safari treats the interaction as a direct switch press.
+
+One `useHaptic()` instance manages one DOM target. If you need haptics on
+multiple elements, call the hook separately for each one.
+
+## Android / Programmatic Trigger
+
+```tsx
+import { useHaptic } from "use-haptic";
+
+function AndroidButton() {
+  const { triggerHaptic } = useHaptic();
+
+  return (
+    <button
+      onClick={() => {
+        triggerHaptic();
+      }}
+      type="button"
+    >
+      Vibrate
+    </button>
+  );
+}
+```
+
+`triggerHaptic()` still uses `navigator.vibrate()` on non-iOS browsers, but it
+should no longer be considered a reliable arbitrary-trigger API on modern iOS
+Safari.
 
 ## 🏃‍♂️ Quick Start
 

--- a/deno.json
+++ b/deno.json
@@ -7,6 +7,8 @@
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/testing": "jsr:@std/testing@^1.0.17",
     "@testing-library/react": "npm:@testing-library/react@^16.3.2",
+    "@types/react": "npm:@types/react@^19.1.0",
+    "@types/react/jsx-runtime": "npm:@types/react@^19.1.0/jsx-runtime",
     "global-jsdom": "npm:global-jsdom@24",
     "react": "npm:react@^19.2.5",
     "react-dom": "npm:react-dom@^19.2.5"

--- a/deno.lock
+++ b/deno.lock
@@ -26,7 +26,8 @@
     "jsr:@std/testing@^1.0.17": "1.0.17",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
-    "npm:@testing-library/react@^16.3.2": "16.3.2_@testing-library+dom@10.4.1_react@19.2.5_react-dom@19.2.5__react@19.2.5",
+    "npm:@testing-library/react@^16.3.2": "16.3.2_@types+react@19.2.14_react@19.2.5_react-dom@19.2.5__react@19.2.5",
+    "npm:@types/react@^19.1.0": "19.2.14",
     "npm:global-jsdom@24": "24.0.0_jsdom@24.1.3",
     "npm:react-dom@^19.2.5": "19.2.5_react@19.2.5",
     "npm:react@^19.2.5": "19.2.5"
@@ -216,17 +217,27 @@
         "pretty-format"
       ]
     },
-    "@testing-library/react@16.3.2_@testing-library+dom@10.4.1_react@19.2.5_react-dom@19.2.5__react@19.2.5": {
+    "@testing-library/react@16.3.2_@types+react@19.2.14_react@19.2.5_react-dom@19.2.5__react@19.2.5": {
       "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dependencies": [
         "@babel/runtime",
         "@testing-library/dom",
+        "@types/react",
         "react",
         "react-dom"
+      ],
+      "optionalPeers": [
+        "@types/react"
       ]
     },
     "@types/aria-query@5.0.4": {
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
+    },
+    "@types/react@19.2.14": {
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dependencies": [
+        "csstype"
+      ]
     },
     "agent-base@7.1.3": {
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
@@ -265,6 +276,9 @@
         "@asamuzakjp/css-color",
         "rrweb-cssom@0.8.0"
       ]
+    },
+    "csstype@3.2.3": {
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "data-urls@5.0.0": {
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
@@ -597,6 +611,7 @@
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/testing@^1.0.17",
       "npm:@testing-library/react@^16.3.2",
+      "npm:@types/react@^19.1.0",
       "npm:global-jsdom@24",
       "npm:react-dom@^19.2.5",
       "npm:react@^19.2.5"

--- a/docs/WEBKIT_SWITCH_HAPTIC_INVESTIGATION_2026-04-09.md
+++ b/docs/WEBKIT_SWITCH_HAPTIC_INVESTIGATION_2026-04-09.md
@@ -1,0 +1,71 @@
+# WebKit switch haptic 調査メモ
+
+日付: 2026-04-09
+
+## 調査対象
+
+`use-haptic` は hidden な `<label>` から hidden な
+`<input type="checkbox" switch>` へ click を転送する実装を使っていた。
+その後、label 経由をやめて `input.click()` の直接呼び出しへ切り替えたが、要素は
+`display: none` のままだった。
+
+`iOS 26.5 beta` の実機確認では、この状態でも haptic は発火しなかった。一方で、
+renderable な switch input に対して `click()` を直接呼ぶと haptic が発火する。
+
+この文書は、その実装変更の根拠として確認した公開 WebKit 情報をまとめたもの。
+
+## 根拠一覧
+
+| 日付           | ソース                                                                                         | ID                                                    | 種別     | 要点                                                                                                                                                                               |
+| -------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2023-12-05     | https://github.com/WebKit/WebKit/pull/21156                                                    | PR #21156 / 271542@main                               | 背景     | WebKit は `input[type=checkbox][switch]` の trusted click や pointer tracking の責務を `CheckboxInputType` 側へ寄せている。                                                        |
+| 2025-01-03     | https://bugs.webkit.org/show_bug.cgi?id=285120                                                 | bug 285120                                            | 直接証拠 | bug のタイトルとパッチ説明が、switch haptic feedback に user activation を要求する変更であることを示している。                                                                     |
+| 2025-01-03     | https://github.com/WebKit/WebKit/pull/38473                                                    | PR #38473 / 288403@main                               | 直接証拠 | PR 本文に「script alone では switch haptic feedback を発火できないようにする」と明記されている。                                                                                   |
+| 2025-01-03     | https://github.com/WebKit/WebKit/commit/dfb3971bb0d9ef84f41784e277404aa10a5ad5f3               | `dfb3971` / 288403@main                               | 直接証拠 | `CheckboxInputType::performSwitchVisuallyOnAnimation` に `trigger == SwitchTrigger::Click && !UserGestureIndicator::processingUserGesture()` の early return が追加されている。    |
+| current `main` | https://github.com/WebKit/WebKit/blob/main/Source/WebCore/html/HTMLLabelElement.cpp            | `HTMLLabelElement::defaultEventHandler`               | 補強証拠 | label activation 自体は今も関連 control に `dispatchSimulatedClick` を転送している。つまり label 経路そのものが消えたわけではない。                                                |
+| current `main` | https://github.com/WebKit/WebKit/blob/main/Source/WebCore/dom/Element.cpp                      | `Element::dispatchSimulatedClick`                     | 補強証拠 | simulated click dispatch は今も `SimulatedClickSource::UserAgent` を使っている。label から control への転送実装が単純に削除された形跡はない。                                      |
+| current `main` | https://github.com/WebKit/WebKit/blob/main/Source/WebCore/html/CheckboxInputType.cpp           | `CheckboxInputType::performSwitchVisuallyOnAnimation` | 直接証拠 | switch haptic に対する user activation gate は current `main` にも残っている。                                                                                                     |
+| current `main` | https://raw.githubusercontent.com/WebKit/WebKit/main/Source/WebCore/html/CheckboxInputType.cpp | `CheckboxInputType::performSwitchAnimation`           | 直接証拠 | switch animation は `!element->renderer()` または `!element->renderer()->style().hasUsedAppearance()` の場合に return する。`display: none` の switch はここで落ちる可能性が高い。 |
+
+## 公開ソースから読み取れること
+
+1. WebKit は `288403@main` で switch haptic feedback に対する明示的な guard
+   を追加している。
+2. その変更の目的は、script 単独では haptic を発火できないようにすること。
+3. このライブラリの旧実装は switch 要素そのものへの直接 click ではなく、hidden
+   label 経由の転送 click に依存していた。
+4. current `main` にも label 転送コードは残っているため、最も自然な解釈は「label
+   click が消えた」ではなく、「forward された click 経路が haptic 実行時点で
+   user gesture として認められなくなった」というもの。
+5. さらに current `main` では switch animation 自体が `renderer` と
+   `hasUsedAppearance()` を前提にしているため、`display: none` の switch は
+   direct click でも haptic 経路に乗れない可能性が高い。
+6. そのため、`iOS 26.5 beta` で安定して haptic を出すには、 `input[switch]` を
+   direct に click するだけでなく、要素を renderable のまま
+   視覚的に隠す必要がある。
+
+## 確度と制約
+
+- 高確度: `288403@main` は公開されている実在の WebKit 変更であり、switch haptic
+  の activation 条件を厳しくしている。
+- 高確度: `display: none` の switch を使う実装は、current `main` の
+  `performSwitchAnimation()` の条件と整合しない。
+- 中程度の確度: `iOS 26.5 beta`
+  で観測された回帰は、この変更そのもの、またはこれに近い Apple 内部ブランチ上の
+  event / activation 調整の影響である可能性が高い。
+- 制約: 公開 WebKit の commit / PR の中には、「label click が switch haptic
+  を通さなくなった」と明示した変更は見つかっていない。実際の shipping build
+  に含まれる差分が Apple 内部のみで管理されている可能性は残る。
+
+## ライブラリ側の判断
+
+最終的なライブラリ実装は、programmatic な `triggerHaptic()` に iOS haptic を
+期待しない方針へ切り替えた。
+
+- iOS では、利用側が `ref` を付けた target 要素の上に transparent な native
+  `input[type=checkbox][switch]` を重ねる
+- ユーザーはその native switch を直接押し、WebKit の許容する経路で haptic を出す
+- その後で元の target 要素へ click を forward する
+
+この構成により、public hook interface は保ちつつ、公開 WebKit が導入した
+stricter な user activation モデルに合わせる。

--- a/sample/deno-vite-react/src/components/HapticButton/index.tsx
+++ b/sample/deno-vite-react/src/components/HapticButton/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./style.css";
 import { useHaptic } from "use-haptic";
 
@@ -7,15 +7,34 @@ export const HapticButton = () => {
   const [duration, setDuration] = useState(5000);
   const [interval, setInterval] = useState(100);
   const { ref, triggerHaptic } = useHaptic();
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleLegacyClick = () => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
     if (isContinuous) {
       const startTime = Date.now();
 
       const continuousVibration = () => {
         if (Date.now() - startTime < duration) {
           triggerHaptic();
-          setTimeout(continuousVibration, interval);
+          timeoutRef.current = setTimeout(
+            continuousVibration,
+            Math.max(interval, 16),
+          );
+        } else {
+          timeoutRef.current = null;
         }
       };
 

--- a/sample/deno-vite-react/src/components/HapticButton/index.tsx
+++ b/sample/deno-vite-react/src/components/HapticButton/index.tsx
@@ -6,8 +6,7 @@ export const HapticButton = () => {
   const [isContinuous, setIsContinuous] = useState(false);
   const [duration, setDuration] = useState(5000);
   const [interval, setInterval] = useState(100);
-  const { ref } = useHaptic();
-  const { triggerHaptic } = useHaptic();
+  const { ref, triggerHaptic } = useHaptic();
 
   const handleLegacyClick = () => {
     if (isContinuous) {

--- a/sample/deno-vite-react/src/components/HapticButton/index.tsx
+++ b/sample/deno-vite-react/src/components/HapticButton/index.tsx
@@ -6,9 +6,10 @@ export const HapticButton = () => {
   const [isContinuous, setIsContinuous] = useState(false);
   const [duration, setDuration] = useState(5000);
   const [interval, setInterval] = useState(100);
+  const { ref } = useHaptic();
   const { triggerHaptic } = useHaptic();
 
-  const handleClick = () => {
+  const handleLegacyClick = () => {
     if (isContinuous) {
       const startTime = Date.now();
 
@@ -27,8 +28,20 @@ export const HapticButton = () => {
 
   return (
     <div className="haptic-btn-container">
-      <button className="haptic-btn" onClick={handleClick} type="button">
-        Feel Haptic !!!
+      <button
+        className="haptic-btn"
+        onClick={() => console.log("ref-based haptic target")}
+        ref={ref}
+        type="button"
+      >
+        iOS Ref Haptic
+      </button>
+      <button
+        className="haptic-btn legacy-btn"
+        onClick={handleLegacyClick}
+        type="button"
+      >
+        Android triggerHaptic()
       </button>
       <label>
         <input

--- a/sample/deno-vite-react/src/components/HapticButton/style.css
+++ b/sample/deno-vite-react/src/components/HapticButton/style.css
@@ -13,9 +13,11 @@ label {
 }
 
 .haptic-btn {
+  display: inline-block;
   padding: 20px 30px;
   font-size: 16px;
   border-radius: 8px;
+  border: none;
   background-color: #646cff;
   color: white;
   font-weight: bold;
@@ -23,6 +25,14 @@ label {
 
 .haptic-btn:active {
   background-color: #535bbf;
+}
+
+.legacy-btn {
+  background-color: #3a3a3a;
+}
+
+.legacy-btn:active {
+  background-color: #2a2a2a;
 }
 
 @media (hover: hover) {

--- a/sample/deno-vite-react/vite.config.ts
+++ b/sample/deno-vite-react/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath, URL } from "node:url";
 import { defineConfig, type PluginOption } from "vite";
 import deno from "@deno/vite-plugin";
 import react from "@vitejs/plugin-react-swc";
@@ -6,4 +7,9 @@ import { qrcode } from "vite-plugin-qrcode";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [deno() as PluginOption, react(), qrcode() as PluginOption],
+  resolve: {
+    alias: {
+      "use-haptic": fileURLToPath(new URL("../../src/mod.ts", import.meta.url)),
+    },
+  },
 });

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,16 +1,25 @@
 /**
  * use-haptic
  *
- * A React hook library that provides haptic feedback functionality for mobile web applications.
- * This library uses the `input[switch]` element for iOS devices and the Vibration API for other devices.
+ * A React hook library that provides haptic feedback functionality for mobile
+ * web applications.
+ *
+ * On iOS Safari, attach the returned `ref` to the pressed element so the hook
+ * can place a native `input[switch]` over it. On Android and other browsers,
+ * `triggerHaptic()` uses the Vibration API.
  *
  * @example
  * ```tsx
  * import { useHaptic } from "use-haptic";
  *
  * function HapticButton() {
- *   const { triggerHaptic } = useHaptic();
- *   return <button onClick={triggerHaptic}>Haptic</button>;
+ *   const { ref } = useHaptic();
+ *
+ *   return (
+ *     <button ref={ref} type="button">
+ *       Haptic
+ *     </button>
+ *   );
  * }
  * ```
  */

--- a/src/useHaptic.ts
+++ b/src/useHaptic.ts
@@ -1,68 +1,143 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { detectiOS } from "./utils.ts";
 
 const HAPTIC_DURATION = 5;
+const OVERLAY_DATA_ATTRIBUTE = "data-use-haptic-overlay";
+const OVERLAY_Z_INDEX = "2147483647";
+
+type HapticTarget = HTMLElement & { disabled?: boolean; click: () => void };
+
+export type UseHapticResult = {
+  ref: (node: HTMLElement | null) => void;
+  triggerHaptic: () => void;
+};
+
+const isTargetEligible = (target: HapticTarget): boolean => {
+  if (!document.body.contains(target)) {
+    return false;
+  }
+
+  if ("disabled" in target && Boolean(target.disabled)) {
+    return false;
+  }
+
+  if (target.getAttribute("aria-hidden") === "true") {
+    return false;
+  }
+
+  const computedStyle = globalThis.getComputedStyle(target);
+  if (
+    computedStyle.display === "none" ||
+    computedStyle.visibility === "hidden" ||
+    computedStyle.pointerEvents === "none"
+  ) {
+    return false;
+  }
+
+  const rect = target.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+};
+
+const hideOverlay = (input: HTMLInputElement) => {
+  input.style.display = "none";
+  input.style.pointerEvents = "none";
+};
+
+const syncOverlayPosition = (
+  input: HTMLInputElement,
+  target: HapticTarget,
+) => {
+  if (!isTargetEligible(target)) {
+    hideOverlay(input);
+    return;
+  }
+
+  const rect = target.getBoundingClientRect();
+  input.style.position = "fixed";
+  input.style.left = `${rect.left}px`;
+  input.style.top = `${rect.top}px`;
+  input.style.width = `${rect.width}px`;
+  input.style.height = `${rect.height}px`;
+  input.style.margin = "0";
+  input.style.opacity = "0";
+  input.style.pointerEvents = "auto";
+  input.style.display = "block";
+  input.style.zIndex = OVERLAY_Z_INDEX;
+};
 
 /**
- * React hook for triggering haptic feedback on mobile devices
+ * React hook for mobile haptic feedback.
  *
- * This hook creates hidden DOM elements to trigger haptic feedback using the `input[switch]`
- * element for iOS devices and falls back to the Vibration API for other supported devices.
- *
- * @param {number} duration - The duration of the vibration in milliseconds (default: 5ms)
- * @returns {Object} An object containing the `triggerHaptic` function to trigger haptic feedback
- *
- * @example
- * ```tsx
- * import { useHaptic } from "use-haptic";
- *
- * function HapticButton() {
- *   const { triggerHaptic } = useHaptic(200); // 200ms vibration
- *   return <button onClick={triggerHaptic}>Vibrate</button>;
- * }
- * ```
+ * On iOS Safari, attach `ref` to the pressed element so the hook can place a
+ * transparent native `input[switch]` over it. On Android and other browsers,
+ * `triggerHaptic()` continues to use the Vibration API programmatically.
  */
 export const useHaptic = (
   duration = HAPTIC_DURATION,
-): { triggerHaptic: () => void } => {
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const labelRef = useRef<HTMLLabelElement | null>(null);
+): UseHapticResult => {
+  const [target, setTarget] = useState<HapticTarget | null>(null);
   const isIOS = useMemo(() => detectiOS(), []);
 
+  const ref = useCallback((node: HTMLElement | null) => {
+    setTarget(node as HapticTarget | null);
+  }, []);
+
   useEffect(() => {
-    // Create and append input element
+    if (!isIOS || !target) {
+      return;
+    }
+
     const input = document.createElement("input");
     input.type = "checkbox";
-    input.id = "haptic-switch";
+    input.tabIndex = -1;
     input.setAttribute("switch", "");
-    input.style.display = "none";
+    input.setAttribute("aria-hidden", "true");
+    input.setAttribute(OVERLAY_DATA_ATTRIBUTE, "true");
     document.body.appendChild(input);
-    inputRef.current = input;
 
-    // Create and append label element
-    const label = document.createElement("label");
-    label.htmlFor = "haptic-switch";
-    label.style.display = "none";
-    document.body.appendChild(label);
-    labelRef.current = label;
-
-    // Cleanup function
-    return () => {
-      document.body.removeChild(input);
-      document.body.removeChild(label);
+    const sync = () => syncOverlayPosition(input, target);
+    const handleOverlayClick = () => {
+      target.click();
     };
-  }, []);
+
+    input.addEventListener("click", handleOverlayClick);
+
+    const resizeObserver = typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(sync)
+      : null;
+    resizeObserver?.observe(target);
+
+    const mutationObserver = typeof MutationObserver !== "undefined"
+      ? new MutationObserver(sync)
+      : null;
+    mutationObserver?.observe(target, {
+      attributes: true,
+      childList: false,
+      subtree: false,
+    });
+
+    globalThis.addEventListener("scroll", sync, true);
+    globalThis.addEventListener("resize", sync);
+
+    sync();
+
+    return () => {
+      globalThis.removeEventListener("scroll", sync, true);
+      globalThis.removeEventListener("resize", sync);
+      mutationObserver?.disconnect();
+      resizeObserver?.disconnect();
+      input.removeEventListener("click", handleOverlayClick);
+      input.remove();
+    };
+  }, [isIOS, target]);
 
   const triggerHaptic = useCallback(() => {
     if (!isIOS && navigator?.vibrate) {
       navigator.vibrate(duration);
-    } else {
-      labelRef.current?.click();
     }
-  }, [isIOS, duration]);
+  }, [duration, isIOS]);
 
-  return { triggerHaptic };
+  return { ref, triggerHaptic };
 };
 
-// For backwards compatibility
 export default useHaptic;

--- a/src/useHaptic.ts
+++ b/src/useHaptic.ts
@@ -62,6 +62,7 @@ const syncOverlayPosition = (
   input.style.opacity = "0";
   input.style.pointerEvents = "auto";
   input.style.display = "block";
+  input.style.cursor = globalThis.getComputedStyle(target).cursor || "auto";
   input.style.zIndex = OVERLAY_Z_INDEX;
 };
 
@@ -96,7 +97,8 @@ export const useHaptic = (
     document.body.appendChild(input);
 
     const sync = () => syncOverlayPosition(input, target);
-    const handleOverlayClick = () => {
+    const handleOverlayClick = (event: Event) => {
+      event.preventDefault();
       target.click();
     };
 

--- a/test/useHaptic.test.ts
+++ b/test/useHaptic.test.ts
@@ -3,69 +3,139 @@ jsdom();
 
 import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
-import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
-import { renderHook } from "@testing-library/react";
+import { assertSpyCalls, spy } from "@std/testing/mock";
+import { act, renderHook } from "@testing-library/react";
 import useHaptic from "../src/useHaptic.ts";
 
+const OVERLAY_SELECTOR = "input[data-use-haptic-overlay='true']";
+
+const setUserAgent = (value: string) => {
+  Object.defineProperty(globalThis.navigator, "userAgent", {
+    configurable: true,
+    value,
+  });
+};
+
+const mockRect = (element: HTMLElement) => {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      bottom: 60,
+      height: 40,
+      left: 10,
+      right: 110,
+      top: 20,
+      width: 100,
+      x: 10,
+      y: 20,
+      toJSON: () => "",
+    }),
+  });
+};
+
 describe("useHaptic", () => {
-  it("elements are added on mount and removed on unmount", () => {
-    // wrap document.body.appendChild and removeChild with spy
-    const appendChildSpy = spy(document.body, "appendChild");
-    const removeChildSpy = spy(document.body, "removeChild");
+  it("creates an iOS overlay for the referenced target and forwards clicks", () => {
+    const originalUserAgent = globalThis.navigator.userAgent;
+    setUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)",
+    );
+
+    const target = document.createElement("button");
+    document.body.appendChild(target);
+    mockRect(target);
+
+    const targetClickSpy = spy(target, "click");
 
     try {
-      // render useHaptic hook
-      const { unmount } = renderHook(() => useHaptic());
+      const { result, unmount } = renderHook(() => useHaptic());
 
-      // verify appendChild is called 3 times
-      assertSpyCalls(appendChildSpy, 3);
+      act(() => {
+        result.current.ref(target);
+      });
 
-      // verify tagName of each added element
-      const firstElement = appendChildSpy.calls[0].args[0] as HTMLElement;
-      const secondElement = appendChildSpy.calls[1].args[0] as HTMLElement;
-      const thirdElement = appendChildSpy.calls[2].args[0] as HTMLElement;
+      const overlay = document.querySelector(OVERLAY_SELECTOR) as
+        | HTMLInputElement
+        | null;
+      if (!overlay) {
+        throw new Error("overlay not found");
+      }
 
-      assertEquals(firstElement.tagName, "DIV");
-      assertEquals(secondElement.tagName, "INPUT");
-      assertEquals(thirdElement.tagName, "LABEL");
+      assertEquals(overlay.getAttribute("switch"), "");
+      assertEquals(overlay.style.position, "fixed");
+      assertEquals(overlay.style.left, "10px");
+      assertEquals(overlay.style.top, "20px");
+      assertEquals(overlay.style.width, "100px");
+      assertEquals(overlay.style.height, "40px");
+      assertEquals(overlay.style.opacity, "0");
+      assertEquals(overlay.style.pointerEvents, "auto");
 
-      // unmount hook
+      overlay.click();
+      assertSpyCalls(targetClickSpy, 1);
+
       unmount();
-
-      // verify removeChild is called 2 times after unmount
-      assertSpyCalls(removeChildSpy, 2);
+      assertEquals(document.querySelector(OVERLAY_SELECTOR), null);
     } finally {
-      // restore spy
-      appendChildSpy.restore();
-      removeChildSpy.restore();
+      targetClickSpy.restore();
+      target.remove();
+      setUserAgent(originalUserAgent);
     }
   });
 
-  it("label click is executed when triggerHaptic() is called", () => {
-    // render useHaptic hook
-    const { result } = renderHook(() => useHaptic());
+  it("does not create an iOS overlay for a hidden target", () => {
+    const originalUserAgent = globalThis.navigator.userAgent;
+    setUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)",
+    );
 
-    // get label element added to document.body
-    const label = document.querySelector('label[for="haptic-switch"]') as
-      | HTMLLabelElement
-      | null;
-    if (!label) {
-      throw new Error("label not found");
-    }
-
-    // wrap label.click with spy
-    const labelClickSpy = spy(label, "click");
+    const target = document.createElement("div");
+    target.style.display = "none";
+    document.body.appendChild(target);
+    mockRect(target);
 
     try {
-      // call vibe()
+      const { result, unmount } = renderHook(() => useHaptic());
+
+      act(() => {
+        result.current.ref(target);
+      });
+
+      const overlay = document.querySelector(OVERLAY_SELECTOR) as
+        | HTMLInputElement
+        | null;
+      if (!overlay) {
+        throw new Error("overlay not found");
+      }
+
+      assertEquals(overlay.style.display, "none");
+      assertEquals(overlay.style.pointerEvents, "none");
+      unmount();
+      assertEquals(document.querySelector(OVERLAY_SELECTOR), null);
+    } finally {
+      target.remove();
+      setUserAgent(originalUserAgent);
+    }
+  });
+
+  it("uses navigator.vibrate on non-iOS when triggerHaptic() is called", () => {
+    const originalUserAgent = globalThis.navigator.userAgent;
+    const originalVibrate = navigator.vibrate;
+    setUserAgent("Mozilla/5.0 (Linux; Android 15)");
+
+    navigator.vibrate = (() => true) as typeof navigator.vibrate;
+    const vibrateSpy = spy(navigator, "vibrate");
+
+    try {
+      const { result } = renderHook(() => useHaptic());
+
       result.current.triggerHaptic();
 
-      // verify label.click is called 1 time
-      assertSpyCalls(labelClickSpy, 1);
-      // verify arguments of call
-      assertSpyCall(labelClickSpy, 0, { args: [] });
+      assertSpyCalls(vibrateSpy, 1);
+      assertEquals(vibrateSpy.calls[0].args[0] as unknown, 5);
+      assertEquals(document.querySelector(OVERLAY_SELECTOR), null);
     } finally {
-      labelClickSpy.restore();
+      vibrateSpy.restore();
+      navigator.vibrate = originalVibrate;
+      setUserAgent(originalUserAgent);
     }
   });
 });

--- a/test/useHaptic.test.ts
+++ b/test/useHaptic.test.ts
@@ -81,7 +81,7 @@ describe("useHaptic", () => {
     }
   });
 
-  it("does not create an iOS overlay for a hidden target", () => {
+  it("hides the iOS overlay when the target is ineligible", () => {
     const originalUserAgent = globalThis.navigator.userAgent;
     setUserAgent(
       "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)",


### PR DESCRIPTION
## Summary
- refactor `useHaptic()` so iOS haptics are driven by a target `ref` instead of programmatic clicks
- keep `triggerHaptic()` for Android and other browsers via the Vibration API
- update the Deno Vite sample, tests, and WebKit investigation notes to match the new model

## Testing
- deno fmt --check
- deno lint
- deno test -E
- deno check src/mod.ts
- cd sample/deno-vite-react && deno check src/components/HapticButton/index.tsx
- cd sample/deno-vite-react && deno task build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * useHaptic() now returns { ref, triggerHaptic }; attach ref to the pressed element for iOS haptics.

* **New Features**
  * iOS haptics use a ref-based native overlay for reliable Safari behavior; legacy trigger remains for other platforms.
  * Sample UI updated with a ref-based button and a legacy-style button.

* **Documentation**
  * README and docs updated with new iOS usage guidance and investigation notes.

* **Chores**
  * Added runtime/dev ignore entry and build tooling dependency entries.

* **Tests**
  * Updated tests to cover overlay behavior and platform branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->